### PR TITLE
Fix #7: Add study design classifier and observational execution template

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -14,7 +14,8 @@ Set up `core/`, `domains/`, and `domains/<domain>/tracks/<track>/` before genera
 
 ## 1) Lock objective and decision gate
 Use `references/01-objective-and-gates.md`.
-Output: one-page objective with Go/Hold/Kill and decision date.
+Classify the study design (experimental, quasi-experimental, observational, retrospective) before proceeding. If the objective or domain description contains signals like "natural history", "observational cohort", "registry study", "no intervention", or "disease progression tracking", set study design = observational. If observational or retrospective, set execution plan mode to observational-only and auto-populate out-of-scope constraints with "No treatment, no intervention, no randomization."
+Output: one-page objective with Go/Hold/Kill, decision date, and study design classification.
 
 ## 2) Decompose into top risks
 Use `references/02-risk-breakdown.md`.
@@ -29,7 +30,7 @@ For each top risk, create a Learn Card with:
 - applied artifact
 
 ## 4) Gather and grade evidence
-If biomedical/scientific, use evidence-only workflow and cite PMID/DOI/URL.
+If biomedical/scientific, use evidence-only workflow and cite PMID/DOI/URL. Also check the study design classification from step 1; if observational or retrospective, ensure evidence gathering focuses on observational methods and does not assume interventional capability.
 Map each source to a specific claim in the active Learn Card.
 
 ## 5) Promote decision packet by version
@@ -41,7 +42,8 @@ Promote only when promotion criteria are met:
 
 ## 6) Convert decision to immediate execution
 Use `references/05-day0-7-execution.md`.
-Output: day 0–7 board with owner, threshold, and stop trigger per task.
+Before generating tasks, verify no proposed task requires an intervention incompatible with the study design. If study design = observational or retrospective and a task implies intervention (treatment, vector, compound, protocol manipulation, randomization), flag it with a `> [!warning] Incompatible with observational study design` callout instead of including it. Use the observational study execution template for natural history, observational, or retrospective designs.
+Output: day 0-7 board with owner, threshold, and stop trigger per task.
 
 ## 7) Weekly learning closeout
 Use `references/06-weekly-learning-review.md`.

--- a/references/01-objective-and-gates.md
+++ b/references/01-objective-and-gates.md
@@ -5,6 +5,25 @@
 - Why this matters now:
 - Decision date (local time):
 
+## Study design classification
+
+Before proceeding, classify the study design. This determines what types of execution plans are valid.
+
+| Design type | Intervention allowed | Execution plan type |
+|---|---|---|
+| Experimental / RCT | Yes | Standard interventional plan |
+| Quasi-experimental | Partial | Flag constraints explicitly |
+| Natural history / observational | No | Observational-only plan |
+| Retrospective / registry | No | Observational-only plan |
+
+- Study design: <!-- experimental | quasi-experimental | observational | retrospective -->
+
+**Signal keywords for observational design:** "natural history", "observational cohort", "registry study", "no intervention", "disease progression tracking", "longitudinal observation", "unmanipulated population".
+
+> [!important] If study design = observational or retrospective
+> Auto-populate "Out-of-scope paths" below with: "No treatment, no intervention, no randomization — intervention is prohibited in this study type."
+> Switch execution plan mode to observational-only (see `references/05-day0-7-execution.md` observational template).
+
 ## Decision question
 - By the decision date, what exact choice must be made?
 

--- a/references/05-day0-7-execution.md
+++ b/references/05-day0-7-execution.md
@@ -118,6 +118,50 @@ flowchart LR
 
 ---
 
+## Observational study execution template
+
+When the study design is classified as **observational** or **retrospective** (see `references/01-objective-and-gates.md` study design classification), use this template instead of the standard interventional task board above.
+
+### Incompatibility gate
+
+Before generating any task, verify it does not require applying an intervention. If a proposed task implies treatment, vector selection, compound administration, protocol manipulation, or randomization AND the study design = observational or retrospective, do NOT include it. Instead, insert:
+
+> [!warning] Incompatible with observational study design
+> Task "<task name>" requires an intervention (treatment / manipulation / randomization) that is structurally impossible in a natural history or observational study. Replace with an observational equivalent or remove.
+
+### Observational task categories
+
+Use these task types for observational / natural history study execution plans:
+
+1. **Cohort definition and inclusion/exclusion criteria finalization**
+   - Define the target population
+   - Specify inclusion and exclusion criteria
+   - Document recruitment or data extraction strategy
+
+2. **Endpoint and biomarker selection**
+   - Identify primary and secondary endpoints
+   - Select biomarkers for longitudinal tracking
+   - Define measurement instruments and their validation status
+
+3. **Data collection protocol design**
+   - Design case report forms or data extraction templates
+   - Specify data sources (electronic health records, registries, direct observation)
+   - Define data quality checks and monitoring procedures
+
+4. **Longitudinal follow-up schedule**
+   - Define visit or data collection time points
+   - Specify follow-up duration and intervals
+   - Plan for loss-to-follow-up mitigation
+
+5. **Statistical analysis plan**
+   - Descriptive statistics for cohort characterization
+   - Survival analysis (Kaplan-Meier, Cox regression) where applicable
+   - Trajectory modeling (mixed-effects models, latent class trajectories)
+   - Pre-specify sensitivity analyses
+   - Define handling of missing data
+
+---
+
 <details><summary>Plain-text version (no plugins required)</summary>
 
 ## Execution objective (week 1)

--- a/tests/test_integration.sh
+++ b/tests/test_integration.sh
@@ -390,6 +390,150 @@ else
 fi
 
 # -------------------------------------------------------
+# Test 17: Study design classifier in objective template
+# -------------------------------------------------------
+echo ""
+echo "--- Test 17: Study design classifier in objective template ---"
+
+OBJ_TEMPLATE="$PROJECT_ROOT/references/01-objective-and-gates.md"
+if [ -f "$OBJ_TEMPLATE" ]; then
+  if grep -qi "study design" "$OBJ_TEMPLATE"; then
+    pass "Objective template contains study design section"
+  else
+    fail "Objective template missing study design section"
+  fi
+  if grep -qi "observational" "$OBJ_TEMPLATE"; then
+    pass "Objective template references observational design"
+  else
+    fail "Objective template missing observational design reference"
+  fi
+  if grep -qi "natural history" "$OBJ_TEMPLATE"; then
+    pass "Objective template references natural history studies"
+  else
+    fail "Objective template missing natural history reference"
+  fi
+  if grep -qi "experimental\|RCT" "$OBJ_TEMPLATE"; then
+    pass "Objective template references experimental/RCT design"
+  else
+    fail "Objective template missing experimental/RCT reference"
+  fi
+  if grep -qi "retrospective\|registry" "$OBJ_TEMPLATE"; then
+    pass "Objective template references retrospective/registry design"
+  else
+    fail "Objective template missing retrospective/registry reference"
+  fi
+  if grep -qi "out-of-scope.*intervention\|no treatment.*no intervention\|intervention.*prohibited" "$OBJ_TEMPLATE"; then
+    pass "Objective template has auto-population guidance for observational out-of-scope"
+  else
+    fail "Objective template missing auto-population guidance for observational out-of-scope"
+  fi
+else
+  fail "Objective template does not exist (skipping study design tests)"
+fi
+
+# -------------------------------------------------------
+# Test 18: SKILL.md study design detection
+# -------------------------------------------------------
+echo ""
+echo "--- Test 18: SKILL.md study design detection ---"
+
+if [ -f "$SKILL_FILE" ]; then
+  if grep -qi "study design" "$SKILL_FILE"; then
+    pass "SKILL.md contains study design reference"
+  else
+    fail "SKILL.md missing study design reference"
+  fi
+  if grep -qi "observational" "$SKILL_FILE"; then
+    pass "SKILL.md contains observational reference"
+  else
+    fail "SKILL.md missing observational reference"
+  fi
+  if grep -qi "incompatib\|intervention.*check\|design.*gate\|design.*constraint" "$SKILL_FILE"; then
+    pass "SKILL.md contains incompatibility/intervention gate reference"
+  else
+    fail "SKILL.md missing incompatibility/intervention gate reference"
+  fi
+else
+  fail "SKILL.md does not exist (skipping study design detection tests)"
+fi
+
+# -------------------------------------------------------
+# Test 19: Observational execution template
+# -------------------------------------------------------
+echo ""
+echo "--- Test 19: Observational execution template ---"
+
+EXEC_TEMPLATE="$PROJECT_ROOT/references/05-day0-7-execution.md"
+if [ -f "$EXEC_TEMPLATE" ]; then
+  if grep -qi "observational" "$EXEC_TEMPLATE"; then
+    pass "Execution template contains observational section"
+  else
+    fail "Execution template missing observational section"
+  fi
+  if grep -qi "cohort" "$EXEC_TEMPLATE"; then
+    pass "Execution template contains cohort task type"
+  else
+    fail "Execution template missing cohort task type"
+  fi
+  if grep -qi "endpoint" "$EXEC_TEMPLATE"; then
+    pass "Execution template contains endpoint task type"
+  else
+    fail "Execution template missing endpoint task type"
+  fi
+  if grep -qi "data collection" "$EXEC_TEMPLATE"; then
+    pass "Execution template contains data collection task type"
+  else
+    fail "Execution template missing data collection task type"
+  fi
+  if grep -qi "follow-up\|followup" "$EXEC_TEMPLATE"; then
+    pass "Execution template contains follow-up task type"
+  else
+    fail "Execution template missing follow-up task type"
+  fi
+  if grep -qi "statistical analysis" "$EXEC_TEMPLATE"; then
+    pass "Execution template contains statistical analysis task type"
+  else
+    fail "Execution template missing statistical analysis task type"
+  fi
+else
+  fail "Execution template does not exist (skipping observational template tests)"
+fi
+
+# -------------------------------------------------------
+# Test 20: Incompatibility gate for observational design
+# -------------------------------------------------------
+echo ""
+echo "--- Test 20: Incompatibility gate for observational design ---"
+
+incompatibility_found=false
+if [ -f "$EXEC_TEMPLATE" ]; then
+  if grep -qi "incompatible.*observational\|observational.*study.*design" "$EXEC_TEMPLATE"; then
+    incompatibility_found=true
+  fi
+fi
+if [ -f "$SKILL_FILE" ]; then
+  if grep -qi "incompatible.*observational\|observational.*study.*design" "$SKILL_FILE"; then
+    incompatibility_found=true
+  fi
+fi
+
+if [ "$incompatibility_found" = true ]; then
+  pass "Incompatibility gate reference found for observational study design"
+else
+  fail "Missing incompatibility gate reference for observational study design"
+fi
+
+if [ -f "$EXEC_TEMPLATE" ]; then
+  if grep -q '\[!warning\]' "$EXEC_TEMPLATE"; then
+    pass "Execution template contains warning callout for incompatibility"
+  else
+    fail "Execution template missing warning callout for incompatibility"
+  fi
+else
+  fail "Execution template does not exist (skipping warning callout test)"
+fi
+
+# -------------------------------------------------------
 # Summary
 # -------------------------------------------------------
 echo ""


### PR DESCRIPTION
## Summary
- Add study design classifier at objective-lock step to detect observational/natural history study contexts before generating execution plans
- Add incompatibility gate that blocks interventional tasks when study design is observational, replacing them with warning callouts
- Add observational study execution template with appropriate task categories (cohort, endpoint, data collection, follow-up, statistical analysis)

Fixes #7

## Files Changed
- `references/01-objective-and-gates.md` -- Added "Study design classification" section with 4-type classifier table, signal keywords, and auto-population guidance for out-of-scope constraints
- `references/05-day0-7-execution.md` -- Added "Observational study execution template" with incompatibility gate (warning callout) and 5 observational task categories
- `SKILL.md` -- Added study design detection at step 1, extended step 4 evidence flag for observational designs, added incompatibility gate at step 6
- `tests/test_integration.sh` -- Added 4 new test sections (Tests 17-20) with 17 assertions validating all issue requirements

## Tests
- `Test 17: Study design classifier in objective template` (6 assertions)
- `Test 18: SKILL.md study design detection` (3 assertions)
- `Test 19: Observational execution template` (6 assertions)
- `Test 20: Incompatibility gate for observational design` (2 assertions)

## Test plan
- [x] All new tests pass (`bash tests/test_integration.sh`)
- [x] All pre-existing tests pass
- [ ] Manual verification: invoke skill with a natural history study objective and confirm observational-only plan is generated

Generated with [Claude Code](https://claude.com/claude-code)
